### PR TITLE
Source gen improvements

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <Version>0.11.5</Version>
     <Product>MicroCom</Product>
+    <LangVersion>14</LangVersion>
     <Copyright>Copyright 2021 &#169; Nikita Tsukanov</Copyright>
     <RepositoryUrl>https://github.com/kekekeks/MicroCom</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/UseLocalBuild.targets
+++ b/UseLocalBuild.targets
@@ -7,8 +7,11 @@
 
   <!-- MicroCom Runtime -->
   <ItemGroup Condition="'$(UseMicroCom)' == 'true'">
-    <Reference Include="MicroCom.Runtime">
+    <Reference Include="MicroCom.Runtime" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
       <HintPath>$(MicroComLocalBuildRoot)src\MicroCom.Runtime\bin\Debug\netstandard2.0\MicroCom.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="MicroCom.Runtime" Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+      <HintPath>$(MicroComLocalBuildRoot)src\MicroCom.Runtime\bin\Debug\net8.0\MicroCom.Runtime.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/src/MicroCom.CodeGenerator.MSBuild/MicroCom.CodeGenerator.MSBuild.csproj
+++ b/src/MicroCom.CodeGenerator.MSBuild/MicroCom.CodeGenerator.MSBuild.csproj
@@ -3,7 +3,6 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <BuildOutputTargetFolder>tools</BuildOutputTargetFolder>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-        <LangVersion>8</LangVersion>
 <!--        <DoILRepack>true</DoILRepack>-->
 
     </PropertyGroup>

--- a/src/MicroCom.CodeGenerator.Roslyn/MicroCom.CodeGenerator.Roslyn.csproj
+++ b/src/MicroCom.CodeGenerator.Roslyn/MicroCom.CodeGenerator.Roslyn.csproj
@@ -15,4 +15,10 @@
         <Compile Remove="../MicroCom.CodeGenerator/CSharpGen.Format.cs"/>
     </ItemGroup>
 
+    <ItemGroup>
+        <Content Include="*.props">
+            <Pack>true</Pack>
+            <PackagePath>build\;buildTransitive\;buildMultiTargeting\</PackagePath>
+        </Content>
+    </ItemGroup>
 </Project>

--- a/src/MicroCom.CodeGenerator.Roslyn/MicroCom.CodeGenerator.Roslyn.csproj
+++ b/src/MicroCom.CodeGenerator.Roslyn/MicroCom.CodeGenerator.Roslyn.csproj
@@ -3,7 +3,6 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <IncludeBuildOutput>false</IncludeBuildOutput>
-        <LangVersion>8</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/MicroCom.CodeGenerator.Roslyn/MicroCom.CodeGenerator.Roslyn.props
+++ b/src/MicroCom.CodeGenerator.Roslyn/MicroCom.CodeGenerator.Roslyn.props
@@ -1,0 +1,13 @@
+<Project>
+    <ItemGroup>
+        <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="IsMicroComIdl" />
+    </ItemGroup>
+
+    <Target Name="_InjectMicroComAdditionalFiles" BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun">
+        <ItemGroup>
+            <AdditionalFiles Include="@(MicroComIdl)"
+                             SourceItemGroup="MicroComIdl"
+                             IsMicroComIdl="true" />
+        </ItemGroup>
+    </Target>
+</Project>

--- a/src/MicroCom.CodeGenerator.Roslyn/MicroComRoslynGenerator.cs
+++ b/src/MicroCom.CodeGenerator.Roslyn/MicroComRoslynGenerator.cs
@@ -24,7 +24,7 @@ namespace MicroCom.CodeGenerator.Roslyn
                 {
                     var idl = MicroComCodeGenerator.Parse(file.text);
                     var source = idl.GenerateCSharpInterop();
-                    ctx.AddSource(Path.GetFileNameWithoutExtension(file.path), source);
+                    ctx.AddSource(Path.GetFileNameWithoutExtension(file.path) + ".g.cs", source);
                 }
                 catch (ParseException pe)
                 {

--- a/src/MicroCom.CodeGenerator.Roslyn/MicroComRoslynGenerator.cs
+++ b/src/MicroCom.CodeGenerator.Roslyn/MicroComRoslynGenerator.cs
@@ -5,19 +5,33 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace MicroCom.CodeGenerator.Roslyn
 {
-
     [Generator]
     public class MicroComGenerator : IIncrementalGenerator
     {
+        private const string IsMicroComIdlMetadata = "build_metadata.AdditionalFiles.IsMicroComIdl";
+
         public void Initialize(IncrementalGeneratorInitializationContext context)
         {
-            var files = context.AdditionalTextsProvider.Where(t => t.Path.ToLowerInvariant().EndsWith(".mcidl"))
+            var files = context.AdditionalTextsProvider
+                .Combine(context.AnalyzerConfigOptionsProvider)
+                .Where(t =>
+                {
+                    var (file, optionsProvider) = t;
+
+                    if (optionsProvider.GetOptions(file).TryGetValue(IsMicroComIdlMetadata, out var isMicroComIdl)
+                        && bool.TryParse(isMicroComIdl, out var isIdl) && isIdl)
+                    {
+                        return true;
+                    }
+
+                    return false;
+                })
                 .Select((t, c) => new
                 {
-                    path = t.Path,
-                    text = t.GetText(c)?.ToString()
+                    path = t.Left.Path,
+                    text = t.Left.GetText(c)?.ToString()
                 });
-            
+
             context.RegisterSourceOutput(files, (ctx, file) =>
             {
                 try

--- a/src/MicroCom.CodeGenerator/MicroCom.CodeGenerator.csproj
+++ b/src/MicroCom.CodeGenerator/MicroCom.CodeGenerator.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <LangVersion>8</LangVersion>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0" />


### PR DESCRIPTION
1. Add ".g" suffix, otherwise rider complains about warnings inside
2. Instead of hardcoding extension, filter AdditionalFiles by `IsMicroComIdl` item group property (a more common approach, we have similar with AvaloniaXaml too)
3. Fix local MicroCom local builds targeting .net 8 (netstandard was hardcoded). Let's ignore net5 existence here.

And LangVersion is less relevant